### PR TITLE
Redesign DumbDev homepage as macOS desktop

### DIFF
--- a/src/frontend/apps/index.md
+++ b/src/frontend/apps/index.md
@@ -1,7 +1,7 @@
 ---
 layout: home
-title: "Web Developer Tools"
-description: "A collection of independent micro apps for web developers"
+title: "DumbDev Desktop"
+description: "A fake macOS desktop stuffed with developer micro tools"
 head:
   - - link
     - rel: canonical
@@ -12,126 +12,364 @@ head:
         {
           "@context": "https://schema.org",
           "@type": "WebSite",
-          "name": "Web Developer Tools",
-          "description": "A collection of independent micro apps for web developers",
+          "name": "DumbDev Desktop",
+          "description": "A fake macOS desktop stuffed with developer micro tools",
           "url": "https://dumbdev.me"
         }
-hero:
-  name: "Web Developer Tools"
-  text: "Powerful micro apps for developers"
-  tagline: "A collection of independent tools designed to simplify your web development workflow"
-  image:
-    src: /logo.svg
-    alt: Web Developer Tools
-  actions:
-    - theme: brand
-      text: Get Started
-      link: /http-codes/
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/shadowlanes/dumbdev
-
-features:
-  - icon: 🔍
-    title: HTTP Codes Explainer
-    details: Quickly lookup and understand HTTP status codes with real-time search and detailed explanations for all standard codes.
-    link: /http-codes/
-    linkText: Explore HTTP Codes
-
-  - icon: 🎨
-    title: Color Palette Extractor
-    details: Extract beautiful color palettes from images using Vibrant.js. Upload, extract, and export colors with ease.
-    link: /color-palette-extractor/
-    linkText: Try Color Extractor
-
-  - icon: 🖼️
-    title: Favicon Builder
-    details: Generate complete favicon sets from PNG or JPEG images entirely in your browser. No server required.
-    link: /favicon-builder/
-    linkText: Build Favicons
-
-  - icon: 📄
-    title: SQL Formatter
-    details: Format SQL queries for MySQL, PostgreSQL, and SQL Server with automatic formatting as you type.
-    link: /sql-formatter/
-    linkText: Format SQL
-
-  - icon: 🌈
-    title: Color Palette Generator
-    details: Generate harmonious color palettes based on color theory principles. Perfect for design projects.
-    link: /color-palette-generator/
-    linkText: Coming Soon →
 ---
 
-## Why Choose These Tools?
-
-<div class="vp-features-wrapper">
-  <div class="vp-feature">
-    <div class="vp-feature-icon">⚡</div>
-    <h3 class="vp-feature-title">Fast & Lightweight</h3>
-    <p class="vp-feature-details">Built with performance in mind. No unnecessary dependencies or bloat.</p>
+<div class="mac-viewport">
+  <div class="menu-bar" role="menubar">
+    <div class="menu-left">
+      <span class="menu-logo" aria-hidden="true"></span>
+      <span class="menu-title">DumbDev</span>
+      <div class="menu-dropdown">
+        <button class="menu-button" type="button" aria-haspopup="true">Debug</button>
+        <div class="menu-panel" role="menu">
+          <a role="menuitem" href="/http-codes/">HTTP Codes Explainer</a>
+          <a role="menuitem" href="/sql-formatter/">SQL Formatter</a>
+        </div>
+      </div>
+      <div class="menu-dropdown">
+        <button class="menu-button" type="button" aria-haspopup="true">Design</button>
+        <div class="menu-panel" role="menu">
+          <a role="menuitem" href="/color-palette-extractor/">Color Palette Extractor</a>
+          <a role="menuitem" href="/color-palette-generator/">Color Palette Generator</a>
+        </div>
+      </div>
+      <div class="menu-dropdown">
+        <button class="menu-button" type="button" aria-haspopup="true">Assets</button>
+        <div class="menu-panel" role="menu">
+          <a role="menuitem" href="/favicon-builder/">Favicon Builder</a>
+        </div>
+      </div>
+    </div>
+    <div class="menu-right">
+      <a class="menu-link" href="https://github.com/shadowlanes/dumbdev" target="_blank" rel="noopener">GitHub</a>
+      <a class="menu-link" href="https://github.com/shadowlanes/dumbdev/issues" target="_blank" rel="noopener">Request Tool</a>
+      <span class="menu-clock" aria-hidden="true">☀︎</span>
+    </div>
   </div>
 
-  <div class="vp-feature">
-    <div class="vp-feature-icon">🎯</div>
-    <h3 class="vp-feature-title">Purpose-Built</h3>
-    <p class="vp-feature-details">Each app focuses on doing one thing exceptionally well.</p>
+  <div class="desktop" role="navigation" aria-label="Desktop shortcuts">
+    <div class="desktop-icons">
+      <a class="desktop-icon" href="/http-codes/">
+        <span class="icon-emoji" aria-hidden="true">🛠️</span>
+        <span class="icon-label">HTTP Codes</span>
+      </a>
+      <a class="desktop-icon" href="/sql-formatter/">
+        <span class="icon-emoji" aria-hidden="true">📄</span>
+        <span class="icon-label">SQL Formatter</span>
+      </a>
+      <a class="desktop-icon" href="/color-palette-extractor/">
+        <span class="icon-emoji" aria-hidden="true">🎨</span>
+        <span class="icon-label">Palette Extractor</span>
+      </a>
+      <a class="desktop-icon" href="/color-palette-generator/">
+        <span class="icon-emoji" aria-hidden="true">🌈</span>
+        <span class="icon-label">Palette Generator</span>
+      </a>
+      <a class="desktop-icon" href="/favicon-builder/">
+        <span class="icon-emoji" aria-hidden="true">🖼️</span>
+        <span class="icon-label">Favicon Builder</span>
+      </a>
+    </div>
   </div>
 
-  <div class="vp-feature">
-    <div class="vp-feature-icon">🚀</div>
-    <h3 class="vp-feature-title">Easy to Use</h3>
-    <p class="vp-feature-details">Intuitive interfaces that require no documentation to get started.</p>
+  <div class="dock" role="navigation" aria-label="Dock shortcuts">
+    <div class="dock-glass">
+      <a class="dock-icon" href="/http-codes/">
+        <span aria-hidden="true">🛠️</span>
+        <span>HTTP Codes</span>
+      </a>
+      <a class="dock-icon" href="/color-palette-extractor/">
+        <span aria-hidden="true">🎨</span>
+        <span>Extractor</span>
+      </a>
+      <a class="dock-icon" href="/favicon-builder/">
+        <span aria-hidden="true">🖼️</span>
+        <span>Favicons</span>
+      </a>
+      <a class="dock-icon" href="/sql-formatter/">
+        <span aria-hidden="true">📄</span>
+        <span>SQL</span>
+      </a>
+      <a class="dock-icon" href="/color-palette-generator/">
+        <span aria-hidden="true">🌈</span>
+        <span>Generator</span>
+      </a>
+    </div>
   </div>
 </div>
 
+<section class="desktop-notes" id="about">
+  <h2>About this fake desktop</h2>
+  <p>
+    DumbDev Desktop is what happens when you mix a love for macOS aesthetics with a deep disdain for repetitive dev chores.
+    Every icon opens a tiny tool that saves you from a tedious Google rabbit hole.
+  </p>
+  <p>
+    Missing a niche tool that should be here? Smash that <a href="https://github.com/shadowlanes/dumbdev/issues">issue tracker</a> and we'll drop it on the desktop.
+  </p>
+</section>
+
 <style scoped>
-.vp-features-wrapper {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
-  margin: 3rem auto;
-  max-width: 1200px;
-  padding: 0 1.5rem;
+.mac-viewport {
+  position: relative;
+  min-height: 80vh;
+  border-radius: 36px;
+  overflow: hidden;
+  box-shadow: 0 40px 80px -40px rgba(0, 0, 0, 0.65);
+  background: radial-gradient(circle at top, rgba(255,255,255,0.35) 0%, rgba(0,0,0,0.2) 60%),
+              linear-gradient(135deg, hsl(221 73% 58%), hsl(268 62% 52%), hsl(12 74% 55%));
+  backdrop-filter: blur(10px);
+  color: #f8fbff;
 }
 
-.vp-feature {
-  background: var(--vp-c-bg-soft);
-  border: 1px solid var(--vp-c-divider);
+.menu-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 1.25rem;
+  background: rgba(20, 24, 34, 0.4);
+  backdrop-filter: blur(25px);
+  font-size: 0.95rem;
+}
+
+.menu-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.menu-logo {
+  font-size: 1.3rem;
+}
+
+.menu-title {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.menu-dropdown {
+  position: relative;
+}
+
+.menu-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font: inherit;
+  font-weight: 500;
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.menu-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.menu-dropdown:hover .menu-button,
+.menu-dropdown:focus-within .menu-button {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.menu-panel {
+  position: absolute;
+  top: 1.8rem;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 190px;
+  padding: 0.4rem 0;
   border-radius: 12px;
-  padding: 2rem;
-  transition: all 0.3s ease;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(16, 20, 30, 0.85);
+  box-shadow: 0 18px 28px -18px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  z-index: 10;
+}
+
+.menu-dropdown:hover .menu-panel,
+.menu-dropdown:focus-within .menu-panel {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.menu-panel a {
+  padding: 0.45rem 1rem;
+  color: inherit;
+  text-decoration: none;
+  transition: background 0.12s ease;
+}
+
+.menu-panel a:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.menu-right {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-weight: 500;
+}
+
+.menu-link {
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.85;
+  transition: opacity 0.12s ease;
+}
+
+.menu-link:hover {
+  opacity: 1;
+}
+
+.menu-clock {
+  font-size: 1.1rem;
+}
+
+.desktop {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4rem 2rem 6rem;
+}
+
+.desktop-icons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 2.5rem;
+  max-width: 640px;
+}
+
+.desktop-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+  color: inherit;
+  filter: drop-shadow(0 10px 18px rgba(0,0,0,0.45));
+}
+
+.desktop-icon:hover .icon-emoji {
+  transform: translateY(-4px) scale(1.04);
+}
+
+.icon-emoji {
+  display: grid;
+  place-items: center;
+  width: 92px;
+  height: 92px;
+  font-size: 2.8rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(14px);
+  transition: transform 0.18s ease;
+}
+
+.icon-label {
+  font-size: 0.95rem;
+  text-align: center;
+  text-shadow: 0 2px 6px rgba(0,0,0,0.5);
+}
+
+.dock {
+  position: absolute;
+  bottom: 1.75rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.dock-glass {
+  display: flex;
+  gap: 0.9rem;
+  padding: 0.9rem 1.4rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(28px);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  pointer-events: auto;
+}
+
+.dock-icon {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 1.8rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.dock-icon span:last-child {
+  font-size: 0.75rem;
+}
+
+.dock-icon:hover {
+  transform: translateY(-6px) scale(1.05);
+}
+
+.desktop-notes {
+  margin: 3rem auto 0;
+  max-width: 720px;
   text-align: center;
 }
 
-.vp-feature:hover {
-  border-color: var(--vp-c-brand-1);
+.desktop-notes h2 {
+  font-size: 1.9rem;
 }
 
-.vp-feature-icon {
-  font-size: 3rem;
-  margin-bottom: 1rem;
-  line-height: 1;
+.desktop-notes p {
+  font-size: 1.02rem;
+  line-height: 1.7;
 }
 
-.vp-feature-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--vp-c-text-1);
-  margin: 0 0 0.75rem 0;
-}
-
-.vp-feature-details {
-  font-size: 0.95rem;
-  line-height: 1.6;
-  color: var(--vp-c-text-2);
-  margin: 0;
+.desktop-notes a {
+  color: var(--vp-c-brand-1);
 }
 
 @media (max-width: 768px) {
-  .vp-features-wrapper {
-    grid-template-columns: 1fr;
-    gap: 1.5rem;
+  .mac-viewport {
+    border-radius: 24px;
+  }
+
+  .menu-bar {
+    flex-direction: column;
+    gap: 0.6rem;
+    align-items: flex-start;
+  }
+
+  .desktop {
+    padding: 3rem 1.5rem 6rem;
+  }
+
+  .desktop-icons {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 2rem;
+  }
+
+  .dock {
+    bottom: 1.2rem;
+  }
+
+  .dock-glass {
+    gap: 0.6rem;
+    padding: 0.8rem 1rem;
   }
 }
 </style>
+


### PR DESCRIPTION
Redesigned homepage as a macOS simple desktop, as the current homepage won't appeal at all to engineers. 